### PR TITLE
Update RAK14014_TP_FT6336U.ino

### DIFF
--- a/examples/RAK14014_TP_FT6336U/RAK14014_TP_FT6336U.ino
+++ b/examples/RAK14014_TP_FT6336U/RAK14014_TP_FT6336U.ino
@@ -13,7 +13,7 @@
 
 FT6336U ft6336u; 
 
-static uint8_t intSattus = false; // TP interrupt generation flag.
+volatile uint8_t intSattus = false; // TP interrupt generation flag.
 
 void setup(void) 
 {


### PR DESCRIPTION
Variables used both inside and outside of an interrupt handler should be marked volatile so the compiler allocates them properly.